### PR TITLE
Feat: Add UserStatus model and migration, update User model and DatabaseSeeder

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,7 @@ use Laravel\Sanctum\HasApiTokens;
 use \App\Models\Role;
 use App\Models\State;
 use App\Models\Province;
+use App\Models\UserStatus;
 class User extends Authenticatable
 {
     use HasApiTokens;
@@ -45,6 +46,7 @@ class User extends Authenticatable
         'monthlyShare',
         'meetingDay',
         'role_id',
+        'user_status_id',
         'last_seen_at',
         'terms',
     ];
@@ -97,5 +99,10 @@ class User extends Authenticatable
     public function province()
     {
         return $this->belongsTo(Province::class, 'province_id');
+    }
+
+    public function userStatus()
+    {
+        return $this->belongsTo(UserStatus::class, 'user_status_id');
     }
 }

--- a/app/Models/UserStatus.php
+++ b/app/Models/UserStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class UserStatus extends Model
+{
+    use HasFactory;
+
+    // Define fillable columns
+    protected $fillable = ['name'];
+
+}

--- a/database/migrations/2014_10_10_174131_create_user_statuses_table.php
+++ b/database/migrations/2014_10_10_174131_create_user_statuses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_statuses');
+    }
+};

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -38,7 +38,7 @@ return new class extends Migration
             $table->foreignId('current_team_id')->nullable();
             $table->string('profile_photo_path', 2048)->nullable();
             // Status: 0->inactivated, 1->active, 2->deleted...etc
-            $table->unsignedBigInteger('status')->default(0);
+            $table->unsignedBigInteger('user_status_id')->default(1);
             $table->string('admin_mail')->nullable();
             $table->timestamp('last_pay')->nullable();
             $table->timestamp('last_seen_at')->nullable();
@@ -47,6 +47,7 @@ return new class extends Migration
             $table->foreign('role_id')->references('id')->on('roles');
             $table->foreign('state_id')->references('id')->on('states');
             $table->foreign('province_id')->references('id')->on('provinces');
+            $table->foreign('user_status_id')->references('id')->on('user_statuses');
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
         $this->call(ProvinceSeeder::class);
         $this->call(RoleSeeder::class);
         $this->call(OfficesSeeder::class);
+        $this->call(UserStatusSeeder::class);
         $this->call(UserSeeder::class);
     }
 }

--- a/database/seeders/UserStatusSeeder.php
+++ b/database/seeders/UserStatusSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\UserStatus;
+
+class UserStatusSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Define an array of status names
+        $statusNames = [
+            'Pending',
+            'Active',
+            'Suspended',
+            'Inactive',
+            'Deleted',
+            'Office Member',
+            'Admin',
+            'Super Admin'
+        ];
+
+        // Loop through the status names and insert them into the statuses table
+        foreach ($statusNames as $name) {
+            UserStatus::create(['name' => $name]);
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes related to user statuses. Here's a summary of the updates:

**1. Added UserStatus model:** Created a new model `UserStatus` to represent different statuses for users.

**2. Created UserStatus migration:** Added a migration file `2014_10_10_174131_create_user_statuses_table.php` to create the `user_statuses` table with an `id` and `name` field.

**3. Updated User model:** Modified the `User` model (`app/Models/User.php`) to include a relationship with the `UserStatus` model and added the `user_status_id` field to the fillable array.

**4. Updated DatabaseSeeder:** Included a call to the `UserStatusSeeder` in the `DatabaseSeeder.php` file to seed user statuses into the database during seeding.

These changes enhance the user management system by providing a structured way to manage user statuses.
