### PR TITLE
Implement User-Officer Association for Administrative Purposes

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -41,6 +41,12 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             $user->updateProfilePhoto($input['photo']);
         }
 
+        // Check if the email has been updated
+        if ($input['email'] !== $user->email) {
+            // Update admin_mail for users with matching admin_mail
+            User::where('admin_mail', $user->email)->update(['admin_mail' => $input['email']]);
+        }
+
         if ($input['email'] !== $user->email &&
             $user instanceof MustVerifyEmail) {
             $this->updateVerifiedUser($user, $input);

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Admin;
+
+class AdminController extends Controller
+{
+    public function index()
+    {
+        // Fetch the Membership officers from the database with user data
+        $officers = Admin::with('user')->where('office_id', 2)->get();
+
+        return response()->json($officers);
+    }
+}

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -35,16 +35,26 @@ class UserController extends Controller
         ->where('office_id', $request->role_id)
         ->first();
 
-    if (!$admin) {
-        // If the user is not an admin for the office, create a new record
-        $admin = new Admin();
-        $admin->user_id = $user->id;
-        $admin->office_id = $request->role_id;
-        $admin->save();
-    }
+        if (!$admin) {
+            // If the user is not an admin for the office, create a new record
+            $admin = new Admin();
+            $admin->user_id = $user->id;
+            $admin->office_id = $request->role_id;
+            $admin->save();
+        }
 
         return response()->json($user);
     }
+
+    public function updateOfficer(Request $request, $id)
+    {
+        $user = User::findOrFail($id);
+        $user->admin_mail = $request->officerMail;
+        $user->save();
+
+        return response()->json($user);
+    }
+
 
     public function approval($userId)
     {

--- a/resources/js/Pages/OfficersModal.vue
+++ b/resources/js/Pages/OfficersModal.vue
@@ -1,0 +1,86 @@
+<template>
+    <!-- Modal for setting a membership officer to the user -->
+    <div v-if="shouldRenderModal" class="fixed inset-0 bg-gray-500 bg-opacity-75 overflow-auto z-50 px-4 py-6">
+        <div class="bg-white rounded-lg shadow-md mx-auto w-full max-w-md p-6">
+            <!-- Modal title -->
+            <h3 class="text-xl font-medium mb-4">Set Membership Officer to the user {{ selectedUserName }}</h3>
+            <!-- Office selection dropdown -->
+            <div class="mb-4">
+                <label for="officer" class="block text-sm font-medium mb-2">Officer:</label>
+                <select id="officer" v-model="selectedOfficer" class="border border-gray-300 rounded-md w-full px-3 py-2 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500">
+                    <!-- Loop through offices to populate dropdown options -->
+                    <option v-for="officer in officers" :key="officer.id" :value="officer.user.email">{{ officer.user.name }}</option>
+                    <!-- Display message if no offices available -->
+                    <option v-if="!officers.length" disabled>No officers available</option>
+                </select>
+            </div>
+            <!-- Buttons for cancel and confirm actions -->
+            <div class="flex justify-end">
+                <button @click="emitCancel" class="bg-white hover:bg-gray-100 text-gray-700 font-medium py-2 px-4 border border-gray-300 rounded-md shadow-sm">Cancel</button>
+                <button @click="emitConfirm(selectedOfficer)" class="bg-indigo-500 hover:bg-indigo-600 text-white font-medium py-2 px-4 border border-indigo-500 rounded-md shadow-sm ml-2">Confirm</button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, defineProps, getCurrentInstance, onMounted } from 'vue';
+
+const instance = getCurrentInstance(); // Get the current component instance
+
+// Define props received from parent component
+const props = defineProps({
+    officers: Array,
+    selectedUserId: Number,
+    showNotification: Function,
+    currentPage: Number,
+    loadUsers: Function,
+    selectedOfficer: Number,
+    selectedUserName: String,
+    showOfficersModal: Boolean,
+    selectedOffice: { type: Object, default: null }
+});
+
+
+const officers = ref([]);
+const selectedOfficer = ref(null);
+const shouldRenderModal = ref(false);
+
+// Function to emit cancel event
+const emitCancel = () => {
+    const showOfficersModal = ref(false);
+    instance.emit('close-modal', showOfficersModal); // Emit the close-modal to false
+    selectedOfficer.value = null;
+};
+
+// Function to emit confirm event and update officer to the user
+const emitConfirm = async (officerMail) => {
+    try {
+        const response = await axios.put(`/api/users-officers/${props.selectedUserId}`, {
+            officerMail: officerMail
+        });
+        props.showNotification('Membership officer set successfully');
+        emitCancel();
+        setTimeout(() => {
+            props.loadUsers(props.currentPage); // Reload users after closing the modal
+        }, 1000);
+    } catch (error) {
+        alert('Error updating membershop officer, please try again');
+    }
+};
+
+onMounted(async () => {
+    try {
+        // Fetch membership officers asynchronously
+        const response = await axios.get('/api/membership-officers');
+        officers.value = response.data;
+        shouldRenderModal.value = true;
+
+        // Set the selectedOfficer
+        selectedOfficer.value = props.selectedOfficer;
+    } catch (error) {
+        alert('Error fetching officers, please reload the page');
+    }
+});
+
+</script>

--- a/resources/js/Pages/UserList.vue
+++ b/resources/js/Pages/UserList.vue
@@ -57,6 +57,7 @@
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 {{ user.admin_name }}
+                                <button @click="setMembershipOfficer(user.id, user.name)">Add</button>
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap">
                                 <button @click="addToOffice(user.id, user.name, user.role_id)">Add</button>
@@ -88,6 +89,19 @@
                 Next
             </button>
         </div>
+        <!-- MembershipOfficeModal component -->
+        <OfficersModal
+            v-if="showOfficersModal"
+            :showOfficersModal="showOfficersModal"
+            :selectedOfficer.sync="selectedOfficer"
+            :selectedUserId="selectedUserId"
+            :selectedUserName="selectedUserName"
+            :showNotification="showNotification"
+            :loadUsers="loadUsers"
+            :currentPage="currentPage"
+            @close-modal="handleCloseModal"
+        >
+        </OfficersModal>
 
         <!-- UserOfficeModal component -->
         <UserOfficeModal
@@ -116,18 +130,43 @@ import AppLayout from '@/Layouts/AppLayout.vue';
 import axios from 'axios';
 import { ref, onMounted } from 'vue';
 import UserOfficeModal from './UserOfficeModal.vue';
-
+import OfficersModal from './OfficersModal.vue';
 
 // Define refs and functions
 const users = ref([]);
 const currentPage = ref(1);
 const lastPage = ref(1);
 const offices = ref([]);
+const officers = ref([]);
 const selectedUserId = ref('');
 const selectedUserName = ref('');
 const selectedUserRole = ref('');
 const showOfficeModal = ref(false);
+const showOfficersModal = ref(false);
+const showMemberOfficeModal = ref(false);
 const selectedOffice = ref(null);
+const selectedOfficer = ref(null);
+
+// Function to add user to office
+const setMembershipOfficer = async (userId, userName) => {
+// Check if offices are already fetched
+    if (offices.value.length === 0) {
+        try {
+            const response = await axios.get('/api/membership-officers');
+            officers.value = response.data; // Update officers with fetched data
+        } catch (error) {
+            alert('Error fetching membership officers, please reload the page');
+        }
+    }
+
+    if (officers.value.length > 0) {
+        selectedUserId.value = userId;
+        selectedUserName.value = userName;
+        showOfficersModal.value = true;
+    } else {
+        alert('No offices available to add user to.');
+    }
+};
 
 // Function to add user to office
 const addToOffice = async (userId, userName, userRole) => {
@@ -190,6 +229,8 @@ onMounted(async () => {
 // Function to handle close-modal event from child component
 const handleCloseModal = (newValue) => {
     showOfficeModal.value = false; // Update showOfficeModal when event is received
+    showOfficersModal.value = false; // Update showOfficersModal when event is received
+    showMemberOfficeModal.value = false; // Update showMemberOfficeModal when event is received
 };
 
 // Function to display a notification

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,8 +7,8 @@ use \App\Http\Controllers\StateController;
 use \App\Http\Controllers\ProvinceController;
 use \App\Http\Controllers\UserController;
 use App\Http\Controllers\OfficeController;
+use App\Http\Controllers\AdminController;
 use App\Http\Controllers\NotificationController;
-
 
 /*
 |--------------------------------------------------------------------------
@@ -58,11 +58,17 @@ Route::get('/api/users', [UserController::class, 'showUserList'])->name('users.s
 // Route for updating user role
 Route::put('/api/users/{id}', [UserController::class, 'updateRole']);
 
+// Route for updating membership officer for a user
+Route::put('/api/users-officers/{id}', [UserController::class, 'updateOfficer']);
+
 // Route for user list data
 Route::get('/users', [UserController::class, 'index'])->name('users.index');
 
 // Route for offices list data
 Route::get('/api/offices', [OfficeController::class, 'index'])->name('offices');
+
+// Route for membership officers list data
+Route::get('/api/membership-officers', [AdminController::class, 'index'])->name('officers');
 
 // Route for fetching the notifications
 Route::get('/api/notifications', [NotificationController::class, 'getUserNotifications']);


### PR DESCRIPTION
This pull request introduces functionality to associate users with officers for administrative purposes, facilitating tasks such as user follow-up, data updates, and approval processes. Here's an overview of the changes:

**1. UpdateUserProfileInformation.php:**
* Added logic to update admin_mail for users with matching admin_mail when their email is changed. This ensures continuity in officer-user associations even after email updates.

**2. UserController.php:**
* Implemented a new method updateOfficer to update the officer associated with a user based on the provided email.

**3. UserList.vue:**
* Integrated a button to set a membership officer for a user, allowing admins to assign officers for administrative tasks directly from the user list interface.
* Added a modal component (OfficersModal.vue) to facilitate officer selection and assignment.

**4. routes/web.php:**
* Added routes to fetch membership officers (/api/membership-officers) and update officers for users (/api/users-officers/{id}).

**5. AdminController.php:**
* Created a new controller to handle fetching membership officers with user data, enabling the retrieval of officer information for administrative purposes.

**6. OfficersModal.vue:**
* Introduced a modal component for selecting and assigning officers to users, enhancing the user interface for officer assignment within the application.

These changes lay the groundwork for efficient administrative workflows within the application, allowing for seamless officer-user associations and streamlined administrative tasks.