### PR TITLE
Restrict Access to Certain Features for Non-Admin Membership Officers

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -10,6 +10,8 @@ use App\Models\Admin;
 use Inertia\Inertia;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
+
 
 class UserController extends Controller
 {
@@ -212,5 +214,22 @@ class UserController extends Controller
         $user->save();
 
         return response()->json(['message' => 'User deleted successfully']);
+    }
+
+    public function getCurrentUser(Request $request)
+    {
+        $userId = Auth::id();
+
+        if ($userId) {
+            $user = DB::table('users')
+                ->leftJoin('admins', 'users.id', '=', 'admins.user_id')
+                ->select('users.*', 'admins.admin as is_admin')
+                ->where('users.id', $userId)
+                ->first();
+
+            return response()->json($user);
+        } else {
+            return response()->json(['error' => 'User not authenticated'], 401);
+        }
     }
 }

--- a/resources/js/Pages/UserList.vue
+++ b/resources/js/Pages/UserList.vue
@@ -33,13 +33,13 @@ assigning an admin, and deleting a user. It also includes pagination and search 
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Last Pay
                                 </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                <th v-if="userIsAdmin" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Admin Name
                                 </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                <th v-if="userIsAdmin" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Add to Office
                                 </th>
-                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                <th v-if="userIsAdmin" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Admin Status
                                 </th>
                                 <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -59,15 +59,15 @@ assigning an admin, and deleting a user. It also includes pagination and search 
                                 <td class="px-6 py-4 whitespace-nowrap">
                                     {{ formatDate(user.last_pay) }}
                                 </td>
-                                <td class="px-6 py-4 whitespace-nowrap">
+                                <td v-if="userIsAdmin" class="px-6 py-4 whitespace-nowrap">
                                     {{ user.admin_name }}
                                     <button @click="setMembershipOfficer(user.id, user.name, user.admin_mail)">Add</button>
                                 </td>
-                                <td class="px-6 py-4 whitespace-nowrap">
+                                <td v-if="userIsAdmin" class="px-6 py-4 whitespace-nowrap">
                                     <button @click="addToOffice(user.id, user.name, user.role_id)">Add</button>
                                 </td>
                                 <!-- ToggleSwitch Component for Admin Status -->
-                                <td class="px-6 py-4 whitespace-nowrap">
+                                <td v-if="userIsAdmin" class="px-6 py-4 whitespace-nowrap">
                                   <ToggleSwitch v-if="user.is_admin !== null" :isAdmin="Boolean(user.is_admin)" :userId="user.id" @toggle="() => toggleAdmin(user.id)" />
                                 </td>
                                 <td>
@@ -174,7 +174,7 @@ assigning an admin, and deleting a user. It also includes pagination and search 
   const selectedOffice = ref(null);
   const selectedOfficer = ref(null);
   const showDeleteModal = ref(false);
-
+  const currentUser = ref(null);
   // Set the search query
   const setSearchQuery = (query) => {
     searchQuery.value = query;
@@ -190,6 +190,10 @@ assigning an admin, and deleting a user. It also includes pagination and search 
     );
   });
   
+  // Computed property to determine if current user is an admin
+  const userIsAdmin = computed(() => {
+    return currentUser.value && currentUser.value.is_admin === 1;
+  });
   // Function to set membership officer for a user
   const setMembershipOfficer = async (userId, userName, officer) => {
     if (officers.value.length === 0) {
@@ -268,6 +272,8 @@ assigning an admin, and deleting a user. It also includes pagination and search 
   // Fetch the initial set of users on component mount
   onMounted(async () => {
     try {
+      const response = await axios.get('/api/current-user');
+      currentUser.value = response.data;
       await loadUsers(1);
     } catch (error) {
       alert('Error fetching users, please reload the page');

--- a/routes/web.php
+++ b/routes/web.php
@@ -112,6 +112,9 @@ Route::middleware([
     Route::post('/toggle-admin/{userId}', [AdminController::class, 'toggleAdmin']);
 });
 
+// Route to get the current user and it's admin status
+Route::middleware('auth:sanctum')->get('/api/current-user', [UserController::class, 'getCurrentUser']);
+
 // Public API Routes
 // Route to fetch states
 Route::get('/api/states', [StateController::class, 'index']);


### PR DESCRIPTION
## Overview:
This pull request introduces functionality to restrict access to certain features for membership officers who are not admins. The changes involve modifying the frontend to conditionally render features based on admin status and adding a new backend route to fetch the current user's admin status.

## Changes:

1. **Frontend (Vue.js) - `UserList.vue`:**
   - Conditional Rendering: Updated the template to conditionally display admin-specific features (Admin Name, Add to Office, Admin Status columns) based on the `userIsAdmin` computed property.
   - State Management: Introduced a new reactive property `currentUser` to store the authenticated user's information.
   - Fetch Current User: Added an API call to `/api/current-user` to retrieve the current user's admin status and set it in `currentUser`.

   ```vue
   <template>
       <!-- Conditional rendering for admin-specific features -->
       <th v-if="userIsAdmin" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           Admin Name
       </th>
       ...
       <td v-if="userIsAdmin" class="px-6 py-4 whitespace-nowrap">
           <ToggleSwitch v-if="user.is_admin !== null" :isAdmin="Boolean(user.is_admin)" :userId="user.id" @toggle="() => toggleAdmin(user.id)" />
       </td>
   </template>
   
   <script setup>
       const currentUser = ref(null);
       const userIsAdmin = computed(() => currentUser.value && currentUser.value.is_admin === 1);
       
       onMounted(async () => {
           const response = await axios.get('/api/current-user');
           currentUser.value = response.data;
       });
   </script>
   ```

2. **Backend (Laravel) - `UserController.php`:**
   - New Method `getCurrentUser`: Added a method to fetch the currently authenticated user's information along with their admin status using a left join on the `admins` table.
   - Authentication Check: The method ensures the user is authenticated before performing the query.

   ```php
   public function getCurrentUser(Request $request)
   {
       $userId = Auth::id();

       if ($userId) {
           $user = DB::table('users')
               ->leftJoin('admins', 'users.id', '=', 'admins.user_id')
               ->select('users.*', 'admins.admin as is_admin')
               ->where('users.id', $userId)
               ->first();

           return response()->json($user);
       } else {
           return response()->json(['error' => 'User not authenticated'], 401);
       }
   }
   ```

3. **Routes (Laravel) - `web.php`:**
   - New Route: Added a new route to handle the request for fetching the current user's information and admin status. This route is protected by the `auth:sanctum` middleware.

   ```php
   Route::middleware('auth:sanctum')->get('/api/current-user', [UserController::class, 'getCurrentUser']);
   ```

## Purpose:
The purpose of these changes is to ensure that only users with admin privileges can access specific features in the application, enhancing security and role-based access control.

## Testing:
- Verified that non-admin membership officers cannot see or interact with admin-specific features.
- Confirmed that admin users have full access to all features.

These enhancements improve the overall user experience and maintain strict access control for sensitive operations within the application.