### PR TITLE
Enhance Login and Register Pages with Translations and Additional Links

### DIFF
--- a/resources/js/Pages/Auth/Login.vue
+++ b/resources/js/Pages/Auth/Login.vue
@@ -7,6 +7,9 @@ import InputError from '@/Components/InputError.vue';
 import InputLabel from '@/Components/InputLabel.vue';
 import PrimaryButton from '@/Components/PrimaryButton.vue';
 import TextInput from '@/Components/TextInput.vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
 
 defineProps({
     canResetPassword: Boolean,
@@ -30,7 +33,7 @@ const submit = () => {
 </script>
 
 <template>
-    <Head title="Log in" />
+    <Head :title="t('login_page.title')" />
 
     <AuthenticationCard>
         <template #logo>
@@ -43,7 +46,7 @@ const submit = () => {
 
         <form @submit.prevent="submit">
             <div>
-                <InputLabel for="email" value="Email" />
+                <InputLabel for="email" :value="t('login_page.email')" />
                 <TextInput
                     id="email"
                     v-model="form.email"
@@ -57,7 +60,7 @@ const submit = () => {
             </div>
 
             <div class="mt-4">
-                <InputLabel for="password" value="Password" />
+                <InputLabel for="password" :value="t('login_page.password')" />
                 <TextInput
                     id="password"
                     v-model="form.password"
@@ -72,19 +75,24 @@ const submit = () => {
             <div class="block mt-4">
                 <label class="flex items-center">
                     <Checkbox v-model:checked="form.remember" name="remember" />
-                    <span class="ms-2 text-sm text-gray-600">Remember me</span>
+                    <span class="ms-2 text-sm text-gray-600">{{ t('login_page.remember') }}</span>
                 </label>
             </div>
 
             <div class="flex items-center justify-end mt-4">
                 <Link v-if="canResetPassword" :href="route('password.request')" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
-                    Forgot your password?
+                    {{ t('login_page.forgot_password') }}
                 </Link>
 
                 <PrimaryButton class="ms-4" :class="{ 'opacity-25': form.processing }" :disabled="form.processing">
-                    Log in
+                    {{ t('login_page.login_button') }}
                 </PrimaryButton>
             </div>
         </form>
+        <div class="mt-4 text-center">
+            <Link :href="route('register')" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                {{ t('login_page.no_account') }} <span class="font-bold">{{ t('login_page.register_here') }}</span>
+            </Link>
+        </div>
     </AuthenticationCard>
 </template>

--- a/resources/js/Pages/Auth/Register.vue
+++ b/resources/js/Pages/Auth/Register.vue
@@ -560,10 +560,15 @@ const passwordMatchError = computed(() => {
                 </PrimaryButton>
             </div>
         </form>
+        <!-- Login link -->
+        <div class="mt-6 text-center">
+            <Link href="/login" class="text-sm text-indigo-600 hover:text-indigo-900">
+                {{ t('register_page.already_registered') }}
+            </Link>
+        </div>    
     </AuthenticationCard>
     <!-- Render the modal when it's visible -->
     <TermsOfService v-if="isModalVisible" :terms="terms" @close="hideModal" />
-
 </template>
 
 <style>

--- a/resources/lang/ar/messages.json
+++ b/resources/lang/ar/messages.json
@@ -145,6 +145,19 @@
         "terms_not_agreed": "يجب عليك الموافقة على الشروط والأحكام أولاً.",
         "next": "التالي",
         "previous": "السابق",
-        "register": "التسجيل"
+        "register": "التسجيل",
+        "already_registered": "مسجل بالفعل؟"
+    },
+    "login_page": {
+        "title" : "تسجيل الدخول",
+        "email" : "البريد الإلكتروني",
+        "password" : "كلمة المرور",
+        "remember" : "تذكرني",
+        "forgot_password" : "هل نسيت كلمة المرور؟",
+        "login_button" : "تسجيل الدخول",
+        "no_account" : "ليس لديك حساب؟",
+        "register_here" : "سجل هنا",
+        "status" : "الحالة",
+        "invalid_credentials" : "بيانات الاعتماد غير صالحة. حاول مرة اخرى."
     }
 }

--- a/resources/lang/en/messages.json
+++ b/resources/lang/en/messages.json
@@ -144,7 +144,19 @@
         "terms_not_agreed": "You must agree to the terms and conditions first.",
         "next": "NEXT",
         "previous": "PREVIOUS",
-        "register": "REGISTER"
-
+        "register": "REGISTER",
+        "already_registered": "Already registered?"
+    },
+    "login_page": {
+        "title" : "Log in",
+        "email" : "Email",
+        "password" : "Password",
+        "remember" : "Remember me",
+        "forgot_password" : "Forgot your password?",
+        "login_button" : "Log in",
+        "no_account" : "Don't have an account?",
+        "register_here" : "Register here",
+        "status" : "Status",
+        "invalid_credentials" : "Invalid credentials. Please try again."
     }
 }


### PR DESCRIPTION
This pull request enhances the user experience on the login and register pages by adding translations and additional navigational links. The changes include:

**Changes in resources/js/Pages/Auth/Login.vue:**
* Added i18n support for the login page to enable localization.
* Updated static text elements to use translation keys from the messages.json files.
* Added a link to the register page for users who don't have an account, using translation keys.

**Changes in resources/js/Pages/Auth/Register.vue:**
* Added a link to the login page for users who are already registered, using translation keys.

**Changes in resources/lang/ar/messages.json:**
* Added Arabic translations for the login page.
* Updated the register page translations to include a message for already registered users.

**Changes in resources/lang/en/messages.json:**
* Added English translations for the login page.
* Updated the register page translations to include a message for already registered users.

## Summary of Changes
**Login Page (Login.vue):**

* Added import and use of useI18n for translations.
* Updated title, labels, button text, and links to use translation keys.
* Added a new link for users to register if they don't have an account.

**Register Page (Register.vue):**

* Added a link for users to navigate to the login page if they are already registered.

**Translation Files:**

* **ar/messages.json:**
  * Added translations for the login page elements.
  * Updated the register page with the new translation key for already registered users.

* **en/messages.json:**
  * Added translations for the login page elements.
  * Updated the register page with the new translation key for already registered users.

These changes improve the overall usability of the authentication pages by providing localized text and additional navigational aids, ensuring a smoother user experience for both Arabic and English users.